### PR TITLE
添加了gorm创建数据表时的属性设置使用utf8mb4字符集

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-MYSQL_DSN="db_user@/db_name?charset=utf8&parseTime=True&loc=Local"
+MYSQL_DSN="db_user@/db_name?charset=utf8mb4&parseTime=True&loc=Local"
 REDIS_ADDR="127.0.0.1:6379"
 REDIS_PW=""
 REDIS_DB=""

--- a/model/init.go
+++ b/model/init.go
@@ -27,6 +27,8 @@ func Database(connString string) {
 	db.DB().SetMaxOpenConns(100)
 	//超时
 	db.DB().SetConnMaxLifetime(time.Second * 30)
+	//设置创建数据表时的一些属性
+	db = db.Set("gorm:table_options", "ENGINE=InnoDB CHARSET=utf8")
 
 	DB = db
 


### PR DESCRIPTION
添加了gorm创建数据表时的属性设置，使用utf8mb4字符集，同时修改了.env示例文件的数据库连接字符集
默认不加此设置时，会使用latin1_swedish_ci字符集，在一些情况下会出现不能插入中文数据的错误